### PR TITLE
Update PircBot.java to fix reconnect() 

### DIFF
--- a/src/main/java/org/jibble/pircbot/PircBot.java
+++ b/src/main/java/org/jibble/pircbot/PircBot.java
@@ -140,6 +140,7 @@ public abstract class PircBot implements ReplyConstants {
         _server = hostname;
         _port = port;
         _password = password;
+        _socketFactory = socketFactory;
         
         if (isConnected()) {
             throw new IOException("The PircBot is already connected to an IRC server.  Disconnect first.");


### PR DESCRIPTION
reconnect() would never work because _socketFactory was never assigned in the connect method, thus getSocketFactory() always returned null
